### PR TITLE
Use total order for float comparisons in lexicographical compares

### DIFF
--- a/arrow/src/compute/kernels/merge.rs
+++ b/arrow/src/compute/kernels/merge.rs
@@ -509,7 +509,7 @@ struct FloatComparator<'a, F: ArrowPrimitiveType> {
     arrays: Vec<&'a PrimitiveArray<F>>,
 }
 
-trait FloatCmp {
+pub(crate) trait FloatCmp {
     fn total_cmp(self, r: Self) -> Ordering;
 }
 


### PR DESCRIPTION
It was already used when comparing single-value columns.
CubeStore requires this on compactions to produce correct results.