### PR TITLE
chore: Adds SerializedFileReader::new_with_metadata to avoid reading metadata from file on every invocation #3

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,7 @@
 name: Integration
 
 on:
-  # push:
+  push:
   pull_request:
 
 jobs:
@@ -87,6 +87,7 @@ jobs:
         # the hardcoded version is wrong and should be removed either
         # after https://issues.apache.org/jira/browse/ARROW-13083
         # gets fixes or pyarrow 5.0 gets released
+        hardcoded version is wrong, bot contains
         run: pip install --index-url https://pypi.fury.io/arrow-nightlies/ pyarrow==3.1.0.dev1030
       - name: Run tests
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,8 +18,8 @@
 name: Integration
 
 on:
-  push:
-  pull_request:
+  # push:
+  # pull_request:
 
 jobs:
 
@@ -87,7 +87,6 @@ jobs:
         # the hardcoded version is wrong and should be removed either
         # after https://issues.apache.org/jira/browse/ARROW-13083
         # gets fixes or pyarrow 5.0 gets released
-        hardcoded version is wrong, bot contains
         run: pip install --index-url https://pypi.fury.io/arrow-nightlies/ pyarrow==3.1.0.dev1030
       - name: Run tests
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,7 +19,7 @@ name: Integration
 
 on:
   # push:
-  # pull_request:
+  pull_request:
 
 jobs:
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -126,7 +126,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [nightly-2021-07-04]
+        rust: []
     container:
       image: ${{ matrix.arch }}/rust
       env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [stable]
+        rust: [nightly-2021-07-04]
     container:
       image: ${{ matrix.arch }}/rust
       env:
@@ -73,7 +73,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [stable]
+        rust: [nightly-2021-07-04]
     container:
       image: ${{ matrix.arch }}/rust
       env:
@@ -174,7 +174,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest]
-        rust: [stable]
+        rust: [nightly-2021-07-04]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -202,7 +202,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [stable]
+        rust: [nightly-2021-07-04]
     container:
       image: ${{ matrix.arch }}/rust
       env:
@@ -257,7 +257,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [stable]
+        rust: [nightly-2021-07-04]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -341,7 +341,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [stable]
+        rust: [nightly-2021-07-04]
     container:
       image: ${{ matrix.arch }}/rust
       env:

--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -262,18 +262,28 @@ fn like_utf8_impl<OffsetSize: StringOffsetSizeTrait>(
             regex
         } else {
             let mut prev_char = None;
-            let mut re_pattern = pat.replace(|c| {
-                let res = c == '%' && prev_char != Some('\\');
-                prev_char = Some(c);
-                res
-            }, ".*").replace("\\%", "%");
+            let mut re_pattern = pat
+                .replace(
+                    |c| {
+                        let res = c == '%' && prev_char != Some('\\');
+                        prev_char = Some(c);
+                        res
+                    },
+                    ".*",
+                )
+                .replace("\\%", "%");
 
             let mut prev_char = None;
-            re_pattern = re_pattern.replace(|c| {
-                let res = c == '_' && prev_char != Some('\\');
-                prev_char = Some(c);
-                res
-            }, ".").replace("\\_", "_");
+            re_pattern = re_pattern
+                .replace(
+                    |c| {
+                        let res = c == '_' && prev_char != Some('\\');
+                        prev_char = Some(c);
+                        res
+                    },
+                    ".",
+                )
+                .replace("\\_", "_");
             let re = RegexBuilder::new(&format!("^{}$", re_pattern))
                 .case_insensitive(!case_sensitive)
                 .build()
@@ -383,18 +393,28 @@ fn like_utf8_scalar_impl<OffsetSize: StringOffsetSizeTrait>(
         }
     } else {
         let mut prev_char = None;
-        let mut re_pattern = right.replace(|c| {
-            let res = c == '%' && prev_char != Some('\\');
-            prev_char = Some(c);
-            res
-        }, ".*").replace("\\%", "%");
+        let mut re_pattern = right
+            .replace(
+                |c| {
+                    let res = c == '%' && prev_char != Some('\\');
+                    prev_char = Some(c);
+                    res
+                },
+                ".*",
+            )
+            .replace("\\%", "%");
 
         let mut prev_char = None;
-        re_pattern = re_pattern.replace(|c| {
-            let res = c == '_' && prev_char != Some('\\');
-            prev_char = Some(c);
-            res
-        }, ".").replace("\\_", "_");
+        re_pattern = re_pattern
+            .replace(
+                |c| {
+                    let res = c == '_' && prev_char != Some('\\');
+                    prev_char = Some(c);
+                    res
+                },
+                ".",
+            )
+            .replace("\\_", "_");
         let re = RegexBuilder::new(&format!("^{}$", re_pattern))
             .case_insensitive(!case_sensitive)
             .build()

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -138,6 +138,7 @@ impl<R: 'static + ChunkReader> SerializedFileReader<R> {
         })
     }
 
+    /// Creates file reader from a Parquet file, using pre-read metadata.
     pub fn new_with_metadata(chunk_reader: R, metadata: ParquetMetaData) -> Self {
         Self {
             chunk_reader: Arc::new(chunk_reader),

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -138,6 +138,13 @@ impl<R: 'static + ChunkReader> SerializedFileReader<R> {
         })
     }
 
+    pub fn new_with_metadata(chunk_reader: R, metadata: ParquetMetaData) -> Self {
+        Self {
+            chunk_reader: Arc::new(chunk_reader),
+            metadata,
+        }
+    }
+
     /// Filters row group metadata to only those row groups,
     /// for which the predicate function returns true
     pub fn filter_row_groups(


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change
 
Enable caching of ParquetMetaData in cube.js/arrow-datafusion.

# What changes are included in this PR?

See above.

# Are there any user-facing changes?

New api: SerializedFileReader::new_with_metadata
