### PR TITLE
feat: Track size for ParquetMetadata

### DIFF
--- a/parquet/src/file/footer.rs
+++ b/parquet/src/file/footer.rs
@@ -117,7 +117,11 @@ pub fn parse_metadata<R: ChunkReader>(chunk_reader: &R) -> Result<ParquetMetaDat
         schema_descr,
         column_orders,
     );
-    Ok(ParquetMetaData::new_with_size(file_metadata, row_groups, footer_metadata_len as u32))
+    Ok(ParquetMetaData::new_with_size(
+        file_metadata,
+        row_groups,
+        footer_metadata_len as u32,
+    ))
 }
 
 /// Parses column orders from Thrift definition.

--- a/parquet/src/file/footer.rs
+++ b/parquet/src/file/footer.rs
@@ -117,7 +117,7 @@ pub fn parse_metadata<R: ChunkReader>(chunk_reader: &R) -> Result<ParquetMetaDat
         schema_descr,
         column_orders,
     );
-    Ok(ParquetMetaData::new(file_metadata, row_groups))
+    Ok(ParquetMetaData::new(file_metadata, row_groups, footer_metadata_len))
 }
 
 /// Parses column orders from Thrift definition.

--- a/parquet/src/file/footer.rs
+++ b/parquet/src/file/footer.rs
@@ -117,7 +117,7 @@ pub fn parse_metadata<R: ChunkReader>(chunk_reader: &R) -> Result<ParquetMetaDat
         schema_descr,
         column_orders,
     );
-    Ok(ParquetMetaData::new(file_metadata, row_groups, footer_metadata_len))
+    Ok(ParquetMetaData::new_with_size(file_metadata, row_groups, footer_metadata_len as u32))
 }
 
 /// Parses column orders from Thrift definition.

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -50,14 +50,18 @@ use crate::schema::types::{
 pub struct ParquetMetaData {
     file_metadata: FileMetaData,
     row_groups: Vec<RowGroupMetaData>,
-    /// See footer::parse_metadata
-    metadata_size: usize,
+    /// Size of serialized metadata. See footer::parse_metadata
+    metadata_size: u32,
 }
 
 impl ParquetMetaData {
     /// Creates Parquet metadata from file metadata and a list of row group metadata `Arc`s
     /// for each available row group.
-    pub fn new(file_metadata: FileMetaData, row_groups: Vec<RowGroupMetaData>, metadata_size: usize) -> Self {
+    pub fn new(file_metadata: FileMetaData, row_groups: Vec<RowGroupMetaData>) -> Self {
+        ParquetMetaData::new_with_size(file_metadata, row_groups, 0)
+    }
+
+    pub fn new_with_size(file_metadata: FileMetaData, row_groups: Vec<RowGroupMetaData>, metadata_size: u32) -> Self {
         ParquetMetaData {
             file_metadata,
             row_groups,
@@ -74,6 +78,8 @@ impl ParquetMetaData {
     pub fn num_row_groups(&self) -> usize {
         self.row_groups.len()
     }
+
+    pub fn metadata_size(&self) -> u32 { self.metadata_size }
 
     /// Returns row group metadata for `i`th position.
     /// Position should be less than number of row groups `num_row_groups`.

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -61,7 +61,11 @@ impl ParquetMetaData {
         ParquetMetaData::new_with_size(file_metadata, row_groups, 0)
     }
 
-    pub fn new_with_size(file_metadata: FileMetaData, row_groups: Vec<RowGroupMetaData>, metadata_size: u32) -> Self {
+    pub fn new_with_size(
+        file_metadata: FileMetaData,
+        row_groups: Vec<RowGroupMetaData>,
+        metadata_size: u32,
+    ) -> Self {
         ParquetMetaData {
             file_metadata,
             row_groups,
@@ -79,7 +83,9 @@ impl ParquetMetaData {
         self.row_groups.len()
     }
 
-    pub fn metadata_size(&self) -> u32 { self.metadata_size }
+    pub fn metadata_size(&self) -> u32 {
+        self.metadata_size
+    }
 
     /// Returns row group metadata for `i`th position.
     /// Position should be less than number of row groups `num_row_groups`.

--- a/parquet/src/file/metadata.rs
+++ b/parquet/src/file/metadata.rs
@@ -50,15 +50,18 @@ use crate::schema::types::{
 pub struct ParquetMetaData {
     file_metadata: FileMetaData,
     row_groups: Vec<RowGroupMetaData>,
+    /// See footer::parse_metadata
+    metadata_size: usize,
 }
 
 impl ParquetMetaData {
     /// Creates Parquet metadata from file metadata and a list of row group metadata `Arc`s
     /// for each available row group.
-    pub fn new(file_metadata: FileMetaData, row_groups: Vec<RowGroupMetaData>) -> Self {
+    pub fn new(file_metadata: FileMetaData, row_groups: Vec<RowGroupMetaData>, metadata_size: usize) -> Self {
         ParquetMetaData {
             file_metadata,
             row_groups,
+            metadata_size,
         }
     }
 

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -158,7 +158,7 @@ impl<R: 'static + ChunkReader> SerializedFileReader<R> {
                 filtered_row_groups.push(row_group_metadata.clone());
             }
         }
-        self.metadata = ParquetMetaData::new(
+        self.metadata = ParquetMetaData::new_with_size(
             self.metadata.file_metadata().clone(),
             filtered_row_groups,
             self.metadata.metadata_size(),

--- a/parquet/src/file/serialized_reader.rs
+++ b/parquet/src/file/serialized_reader.rs
@@ -161,6 +161,7 @@ impl<R: 'static + ChunkReader> SerializedFileReader<R> {
         self.metadata = ParquetMetaData::new(
             self.metadata.file_metadata().clone(),
             filtered_row_groups,
+            self.metadata.metadata_size(),
         );
     }
 }


### PR DESCRIPTION
# Which issue does this PR close?

N/A

# Rationale for this change

Weight ParquetMetadataCache by metadata size. 

# What changes are included in this PR?

Adds `ParquetMetadata::new_with_size` to construct a ParquetMetadata tracking size. Updates `footer::parse_metadata` to track the metadata (disk) size explicitly. 
