### PR TITLE
ci: Lock Rust toolchain in workflows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [stable]
+        rust: [nightly-2022-03-08]
     container:
       image: ${{ matrix.arch }}/rust
       env:
@@ -74,7 +74,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [stable]
+        rust: [nightly-2022-03-08]
     container:
       image: ${{ matrix.arch }}/rust
       env:
@@ -188,7 +188,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest]
-        rust: [stable]
+        rust: [nightly-2022-03-08]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -216,7 +216,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [stable]
+        rust: [nightly-2022-03-08]
     container:
       image: ${{ matrix.arch }}/rust
       env:
@@ -256,7 +256,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [stable]
+        rust: [nightly-2022-03-08]
     container:
       image: ${{ matrix.arch }}/rust
       env:
@@ -299,8 +299,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup toolchain
         run: |
-          rustup toolchain install stable
-          rustup default stable
+          rustup toolchain install nightly-2022-03-08
+          rustup default nightly-2022-03-08
           rustup component add rustfmt
       - name: Run
         run: cargo fmt --all -- --check
@@ -446,7 +446,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [stable]
+        rust: [nightly-2022-03-08]
     container:
       image: ${{ matrix.arch }}/rust
       env:


### PR DESCRIPTION
This PR locks Rust toolchain in workflows in addition to the recently locked development environment.