### PR TITLE
fix: Escape regex symbols in all versions of like operator

### DIFF
--- a/arrow/src/compute/kernels/comparison.rs
+++ b/arrow/src/compute/kernels/comparison.rs
@@ -237,6 +237,47 @@ pub fn ilike_utf8<OffsetSize: StringOffsetSizeTrait>(
     like_utf8_impl(left, right, false, false)
 }
 
+fn like_to_regex(pat: &str) -> Result<String> {
+    let mut is_escaped = false;
+    let mut re_pattern = String::new();
+    let regex_chars = "-[]{}()*+?.,^$|#";
+    for c in pat.chars() {
+        if is_escaped {
+            is_escaped = false;
+            if c == '%' {
+                re_pattern.push('%');
+                continue;
+            } else if c == '_' {
+                re_pattern.push('_');
+                continue;
+            } else if c == '\\' {
+                re_pattern.push_str("\\\\");
+                continue;
+            }
+        }
+
+        if regex_chars.find(c).is_some() {
+            re_pattern.push('\\');
+            re_pattern.push(c);
+        } else if c == '%' {
+            re_pattern.push_str(".*");
+        } else if c == '_' {
+            re_pattern.push('.');
+        } else if c == '\\' {
+            is_escaped = true;
+        } else {
+            re_pattern.push(c);
+        }
+    }
+    if is_escaped {
+        return Err(ArrowError::InvalidArgumentError(format!(
+            "LIKE pattern must not end with escape character. Pattern {}",
+            pat
+        )));
+    }
+    Ok(re_pattern)
+}
+
 fn like_utf8_impl<OffsetSize: StringOffsetSizeTrait>(
     left: &GenericStringArray<OffsetSize>,
     right: &GenericStringArray<OffsetSize>,
@@ -261,43 +302,7 @@ fn like_utf8_impl<OffsetSize: StringOffsetSizeTrait>(
         let re = if let Some(ref regex) = map.get(pat) {
             regex
         } else {
-            let mut is_escaped = false;
-            let mut re_pattern = String::new();
-            let regex_chars = "-[]{}()*+?.,^$|#";
-            for c in pat.chars() {
-                if is_escaped {
-                    is_escaped = false;
-                    if c == '%' {
-                        re_pattern.push('%');
-                        continue;
-                    } else if c == '_' {
-                        re_pattern.push('_');
-                        continue;
-                    } else if c == '\\' {
-                        re_pattern.push_str("\\\\");
-                        continue;
-                    }
-                }
-
-                if regex_chars.find(c).is_some() {
-                    re_pattern.push('\\');
-                    re_pattern.push(c);
-                } else if c == '%' {
-                    re_pattern.push_str(".*");
-                } else if c == '_' {
-                    re_pattern.push('.');
-                } else if c == '\\' {
-                    is_escaped = true;
-                } else {
-                    re_pattern.push(c);
-                }
-            }
-            if is_escaped {
-                return Err(ArrowError::InvalidArgumentError(format!(
-                    "LIKE pattern must not end with escape character. Pattern {}",
-                    pat
-                )));
-            }
+            let re_pattern = like_to_regex(pat)?;
             let re = RegexBuilder::new(&format!("^{}$", re_pattern))
                 .case_insensitive(!case_sensitive)
                 .build()
@@ -406,29 +411,7 @@ fn like_utf8_scalar_impl<OffsetSize: StringOffsetSizeTrait>(
             }
         }
     } else {
-        let mut prev_char = None;
-        let mut re_pattern = right
-            .replace(
-                |c| {
-                    let res = c == '%' && prev_char != Some('\\');
-                    prev_char = Some(c);
-                    res
-                },
-                ".*",
-            )
-            .replace("\\%", "%");
-
-        let mut prev_char = None;
-        re_pattern = re_pattern
-            .replace(
-                |c| {
-                    let res = c == '_' && prev_char != Some('\\');
-                    prev_char = Some(c);
-                    res
-                },
-                ".",
-            )
-            .replace("\\_", "_");
+        let re_pattern = like_to_regex(right)?;
         let re = RegexBuilder::new(&format!("^{}$", re_pattern))
             .case_insensitive(!case_sensitive)
             .build()


### PR DESCRIPTION
# Which issue does this PR close?

<!---
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #.

# Rationale for this change
 
 <!---
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.
-->

# What changes are included in this PR?

<!---
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

# Are there any user-facing changes?


<!---
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!---
If there are any breaking changes to public APIs, please add the `breaking change` label.
-->
