### PR TITLE
ci: Revert incorrect Cargo.toml edit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,7 +1188,6 @@ dependencies = [
  "thrift",
  "tokio",
  "zstd",
- "zstd-sys",
 ]
 
 [[package]]

--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -38,7 +38,6 @@ brotli = { version = "3.3", optional = true }
 flate2 = { version = "1.0", optional = true }
 lz4 = { version = "1.23", optional = true }
 zstd = { version = "0.11.1", optional = true, default-features = false }
-zstd-sys = { version = "2.0.1", optional = true, default-features = false }
 chrono = { version = "0.4", default-features = false }
 num = "0.4"
 num-bigint = "0.4"
@@ -62,7 +61,7 @@ serde_json = { version = "1.0", features = ["preserve_order"] }
 arrow = { path = "../arrow", version = "11.1.0", default-features = false, features = ["test_utils", "prettyprint"] }
 
 [features]
-default = ["arrow", "snap", "brotli", "flate2", "lz4", "zstd", "zstd-sys", "base64"]
+default = ["arrow", "snap", "brotli", "flate2", "lz4", "zstd", "base64"]
 cli = ["serde_json", "base64", "clap"]
 test_common = []
 # Experimental, unstable functionality primarily used for testing

--- a/parquet_derive/test/dependency/default-features/Cargo.lock
+++ b/parquet_derive/test/dependency/default-features/Cargo.lock
@@ -52,13 +52,11 @@ name = "arrow"
 version = "11.1.0"
 dependencies = [
  "bitflags",
- "cc",
  "chrono",
  "flatbuffers",
  "half",
  "hex",
  "indexmap",
- "jobserver",
  "lazy_static",
  "lexical-core",
  "multiversion",
@@ -68,7 +66,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "zstd-sys",
 ]
 
 [[package]]
@@ -547,7 +544,6 @@ dependencies = [
  "snap",
  "thrift",
  "zstd",
- "zstd-sys",
 ]
 
 [[package]]


### PR DESCRIPTION
This PR reverts an accident edit to `Cargo.toml` introduced in d630c7b.