### PR TITLE
fix: Backport fixes for rust 1.77

### DIFF
--- a/arrow/src/alloc/alignment.rs
+++ b/arrow/src/alloc/alignment.rs
@@ -62,7 +62,7 @@ pub const ALIGNMENT: usize = 1 << 6;
 // - https://github.com/torvalds/linux/blob/master/Documentation/devicetree/bindings/riscv/sifive-l2-cache.txt#L41
 // in general all of them are the same.
 /// Cache and allocation multiple alignment size
-#[cfg(target_arch = "riscv")]
+#[cfg(target_arch = "riscv64")]
 pub const ALIGNMENT: usize = 1 << 6;
 
 // This size is same across all hardware for this architecture.

--- a/arrow/src/array/array_binary.rs
+++ b/arrow/src/array/array_binary.rs
@@ -1021,9 +1021,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "assertion failed: `(left == right)`\n  left: `UInt32`,\n \
-                    right: `UInt8`: BinaryArray can only be created from List<u8> arrays, \
-                    mismatched data types."
+        expected = "BinaryArray can only be created from List<u8> arrays, mismatched data types."
     )]
     fn test_binary_array_from_incorrect_list_array() {
         let values: [u32; 12] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];

--- a/arrow/src/compute/kernels/cast.rs
+++ b/arrow/src/compute/kernels/cast.rs
@@ -3090,35 +3090,41 @@ mod tests {
         let f64_array: ArrayRef = Arc::new(Float64Array::from(f64_values));
 
         let f64_expected = vec![
-            "-9223372036854776000.0",
-            "-2147483648.0",
-            "-32768.0",
-            "-128.0",
-            "0.0",
-            "255.0",
-            "65535.0",
-            "4294967295.0",
-            "18446744073709552000.0",
+            -9223372036854776000.0,
+            -2147483648.0,
+            -32768.0,
+            -128.0,
+            0.0,
+            255.0,
+            65535.0,
+            4294967295.0,
+            18446744073709552000.0,
         ];
         assert_eq!(
             f64_expected,
             get_cast_values::<Float64Type>(&f64_array, &DataType::Float64)
+                .iter()
+                .map(|i| i.parse::<f64>().unwrap())
+                .collect::<Vec<f64>>()
         );
 
         let f32_expected = vec![
-            "-9223372000000000000.0",
-            "-2147483600.0",
-            "-32768.0",
-            "-128.0",
-            "0.0",
-            "255.0",
-            "65535.0",
-            "4294967300.0",
-            "18446744000000000000.0",
+            -9223372000000000000.0,
+            -2147483600.0,
+            -32768.0,
+            -128.0,
+            0.0,
+            255.0,
+            65535.0,
+            4294967300.0,
+            18446744000000000000.0,
         ];
         assert_eq!(
             f32_expected,
             get_cast_values::<Float32Type>(&f64_array, &DataType::Float32)
+                .iter()
+                .map(|i| i.parse::<f32>().unwrap())
+                .collect::<Vec<f32>>()
         );
 
         let i64_expected = vec![
@@ -3365,28 +3371,24 @@ mod tests {
         ];
         let u64_array: ArrayRef = Arc::new(UInt64Array::from(u64_values));
 
-        let f64_expected = vec![
-            "0.0",
-            "255.0",
-            "65535.0",
-            "4294967295.0",
-            "18446744073709552000.0",
-        ];
+        let f64_expected =
+            vec![0.0, 255.0, 65535.0, 4294967295.0, 18446744073709552000.0];
         assert_eq!(
             f64_expected,
             get_cast_values::<Float64Type>(&u64_array, &DataType::Float64)
+                .iter()
+                .map(|i| i.parse::<f64>().unwrap())
+                .collect::<Vec<f64>>()
         );
 
-        let f32_expected = vec![
-            "0.0",
-            "255.0",
-            "65535.0",
-            "4294967300.0",
-            "18446744000000000000.0",
-        ];
+        let f32_expected =
+            vec![0.0, 255.0, 65535.0, 4294967300.0, 18446744000000000000.0];
         assert_eq!(
             f32_expected,
             get_cast_values::<Float32Type>(&u64_array, &DataType::Float32)
+                .iter()
+                .map(|i| i.parse::<f32>().unwrap())
+                .collect::<Vec<f32>>()
         );
 
         let i64_expected = vec!["0", "255", "65535", "4294967295", "null"];
@@ -3658,35 +3660,41 @@ mod tests {
         let i64_array: ArrayRef = Arc::new(Int64Array::from(i64_values));
 
         let f64_expected = vec![
-            "-9223372036854776000.0",
-            "-2147483648.0",
-            "-32768.0",
-            "-128.0",
-            "0.0",
-            "127.0",
-            "32767.0",
-            "2147483647.0",
-            "9223372036854776000.0",
+            -9223372036854776000.0,
+            -2147483648.0,
+            -32768.0,
+            -128.0,
+            0.0,
+            127.0,
+            32767.0,
+            2147483647.0,
+            9223372036854776000.0,
         ];
         assert_eq!(
             f64_expected,
             get_cast_values::<Float64Type>(&i64_array, &DataType::Float64)
+                .iter()
+                .map(|i| i.parse::<f64>().unwrap())
+                .collect::<Vec<f64>>()
         );
 
         let f32_expected = vec![
-            "-9223372000000000000.0",
-            "-2147483600.0",
-            "-32768.0",
-            "-128.0",
-            "0.0",
-            "127.0",
-            "32767.0",
-            "2147483600.0",
-            "9223372000000000000.0",
+            -9223372000000000000.0,
+            -2147483600.0,
+            -32768.0,
+            -128.0,
+            0.0,
+            127.0,
+            32767.0,
+            2147483600.0,
+            9223372000000000000.0,
         ];
         assert_eq!(
             f32_expected,
             get_cast_values::<Float32Type>(&i64_array, &DataType::Float32)
+                .iter()
+                .map(|i| i.parse::<f32>().unwrap())
+                .collect::<Vec<f32>>()
         );
 
         let i64_expected = vec![

--- a/arrow/src/ipc/reader.rs
+++ b/arrow/src/ipc/reader.rs
@@ -347,18 +347,7 @@ fn create_list_array(
     buffers: &[Buffer],
     child_array: ArrayRef,
 ) -> ArrayRef {
-    if let DataType::List(_) = *data_type {
-        let null_count = field_node.null_count() as usize;
-        let mut builder = ArrayData::builder(data_type.clone())
-            .len(field_node.length() as usize)
-            .buffers(buffers[1..2].to_vec())
-            .offset(0)
-            .child_data(vec![child_array.data().clone()]);
-        if null_count > 0 {
-            builder = builder.null_bit_buffer(buffers[0].clone())
-        }
-        make_array(builder.build())
-    } else if let DataType::LargeList(_) = *data_type {
+    if let DataType::List(_) | DataType::LargeList(_) = *data_type {
         let null_count = field_node.null_count() as usize;
         let mut builder = ArrayData::builder(data_type.clone())
             .len(field_node.length() as usize)

--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -5,6 +5,7 @@ dev/release/rat_exclude_files.txt
 arrow/test/data/*
 arrow/test/dependency/*
 .gitattributes
+rust-toolchain.toml
 **.gitignore
 .gitmodules
 Cargo.lock

--- a/parquet/src/record/api.rs
+++ b/parquet/src/record/api.rs
@@ -715,15 +715,19 @@ impl fmt::Display for Field {
             Field::Float(value) => {
                 if !(1e-15..=1e19).contains(&value) {
                     write!(f, "{:E}", value)
+                } else if value.trunc() == value {
+                    write!(f, "{}.0", value)
                 } else {
-                    write!(f, "{:?}", value)
+                    write!(f, "{}", value)
                 }
             }
             Field::Double(value) => {
                 if !(1e-15..=1e19).contains(&value) {
                     write!(f, "{:E}", value)
+                } else if value.trunc() == value {
+                    write!(f, "{}.0", value)
                 } else {
-                    write!(f, "{:?}", value)
+                    write!(f, "{}", value)
                 }
             }
             Field::Decimal(ref value) => {

--- a/parquet/src/schema/parser.rs
+++ b/parquet/src/schema/parser.rs
@@ -371,19 +371,14 @@ impl<'a> Parser<'a> {
                                     "Failed to parse scale for DECIMAL type",
                                 )?;
                                 assert_token(self.tokenizer.next(), ")")?;
-                                logical = Some(LogicalType::DECIMAL(DecimalType {
-                                    scale,
-                                    precision,
-                                }));
-                                converted = ConvertedType::from(logical.clone());
                             } else {
-                                scale = 0;
-                                logical = Some(LogicalType::DECIMAL(DecimalType {
-                                    scale,
-                                    precision,
-                                }));
-                                converted = ConvertedType::from(logical.clone());
+                                scale = 0
                             }
+                            logical = Some(LogicalType::DECIMAL(DecimalType {
+                                scale,
+                                precision,
+                            }));
+                            converted = ConvertedType::from(logical.clone());
                         }
                     }
                     LogicalType::TIME(_) => {

--- a/parquet/src/util/bit_packing.rs
+++ b/parquet/src/util/bit_packing.rs
@@ -79,3584 +79,3584 @@ unsafe fn nullunpacker32(in_buf: *const u32, mut out: *mut u32) -> *const u32 {
 }
 
 unsafe fn unpack1_32(in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) & 1;
+    *out = (in_buf.read_unaligned()) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 1) & 1;
+    *out = ((in_buf.read_unaligned()) >> 1) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 2) & 1;
+    *out = ((in_buf.read_unaligned()) >> 2) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 3) & 1;
+    *out = ((in_buf.read_unaligned()) >> 3) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 4) & 1;
+    *out = ((in_buf.read_unaligned()) >> 4) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 5) & 1;
+    *out = ((in_buf.read_unaligned()) >> 5) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 6) & 1;
+    *out = ((in_buf.read_unaligned()) >> 6) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 7) & 1;
+    *out = ((in_buf.read_unaligned()) >> 7) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) & 1;
+    *out = ((in_buf.read_unaligned()) >> 8) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 9) & 1;
+    *out = ((in_buf.read_unaligned()) >> 9) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 10) & 1;
+    *out = ((in_buf.read_unaligned()) >> 10) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 11) & 1;
+    *out = ((in_buf.read_unaligned()) >> 11) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) & 1;
+    *out = ((in_buf.read_unaligned()) >> 12) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 13) & 1;
+    *out = ((in_buf.read_unaligned()) >> 13) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) & 1;
+    *out = ((in_buf.read_unaligned()) >> 14) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 15) & 1;
+    *out = ((in_buf.read_unaligned()) >> 15) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) & 1;
+    *out = ((in_buf.read_unaligned()) >> 16) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 17) & 1;
+    *out = ((in_buf.read_unaligned()) >> 17) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 18) & 1;
+    *out = ((in_buf.read_unaligned()) >> 18) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 19) & 1;
+    *out = ((in_buf.read_unaligned()) >> 19) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) & 1;
+    *out = ((in_buf.read_unaligned()) >> 20) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 21) & 1;
+    *out = ((in_buf.read_unaligned()) >> 21) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 22) & 1;
+    *out = ((in_buf.read_unaligned()) >> 22) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 23) & 1;
+    *out = ((in_buf.read_unaligned()) >> 23) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 24) & 1;
+    *out = ((in_buf.read_unaligned()) >> 24) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 25) & 1;
+    *out = ((in_buf.read_unaligned()) >> 25) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 26) & 1;
+    *out = ((in_buf.read_unaligned()) >> 26) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 27) & 1;
+    *out = ((in_buf.read_unaligned()) >> 27) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 28) & 1;
+    *out = ((in_buf.read_unaligned()) >> 28) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 29) & 1;
+    *out = ((in_buf.read_unaligned()) >> 29) & 1;
     out = out.offset(1);
-    *out = ((*in_buf) >> 30) & 1;
+    *out = ((in_buf.read_unaligned()) >> 30) & 1;
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack2_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 2);
+    *out = (in_buf.read_unaligned()) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 2) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 4) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 6) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 10) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 18) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 18) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 22) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 22) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 24) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 24) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 26) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 26) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 28) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 28) % (1u32 << 2);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     out = out.offset(1);
     in_buf = in_buf.offset(1);
-    *out = (*in_buf) % (1u32 << 2);
+    *out = (in_buf.read_unaligned()) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 2) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 4) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 6) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 10) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 18) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 18) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 22) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 22) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 24) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 24) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 26) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 26) % (1u32 << 2);
     out = out.offset(1);
-    *out = ((*in_buf) >> 28) % (1u32 << 2);
+    *out = ((in_buf.read_unaligned()) >> 28) % (1u32 << 2);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack3_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 3);
+    *out = (in_buf.read_unaligned()) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 3) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 3) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 6) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 9) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 9) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 15) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 15) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 18) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 18) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 21) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 21) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 24) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 24) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 27) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 27) % (1u32 << 3);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (3 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (3 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 4) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 7) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 7) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 10) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 13) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 13) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 19) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 19) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 22) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 22) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 25) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 25) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 28) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 28) % (1u32 << 3);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (3 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (3 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 5) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 5) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 11) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 11) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 17) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 17) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 23) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 23) % (1u32 << 3);
     out = out.offset(1);
-    *out = ((*in_buf) >> 26) % (1u32 << 3);
+    *out = ((in_buf.read_unaligned()) >> 26) % (1u32 << 3);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack4_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 4);
+    *out = (in_buf.read_unaligned()) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 4) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 24) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 24) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 28) % (1u32 << 4);
-    out = out.offset(1);
-    in_buf = in_buf.offset(1);
-
-    *out = (*in_buf) % (1u32 << 4);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 4) % (1u32 << 4);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 4);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 4);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 4);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 4);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 24) % (1u32 << 4);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 28) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 28) % (1u32 << 4);
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 4);
+    *out = (in_buf.read_unaligned()) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 4) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 24) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 24) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 28) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 28) % (1u32 << 4);
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 4);
+    *out = (in_buf.read_unaligned()) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 4) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 24) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 24) % (1u32 << 4);
     out = out.offset(1);
-    *out = ((*in_buf) >> 28) % (1u32 << 4);
+    *out = ((in_buf.read_unaligned()) >> 28) % (1u32 << 4);
+    out = out.offset(1);
+    in_buf = in_buf.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 4);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 4);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 4);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 4);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 4);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 4);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 24) % (1u32 << 4);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 28) % (1u32 << 4);
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack5_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 5);
+    *out = (in_buf.read_unaligned()) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 5) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 5) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 10) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 15) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 15) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 25) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 25) % (1u32 << 5);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (5 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (5 - 3);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 3) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 3) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 13) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 13) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 18) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 18) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 23) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 23) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 28) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 28) % (1u32 << 5);
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (5 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (5 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 6) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 11) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 11) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 21) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 21) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 26) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 26) % (1u32 << 5);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (5 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (5 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 9) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 9) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 19) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 19) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 24) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 24) % (1u32 << 5);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (5 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (5 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 7) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 7) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 17) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 17) % (1u32 << 5);
     out = out.offset(1);
-    *out = ((*in_buf) >> 22) % (1u32 << 5);
+    *out = ((in_buf.read_unaligned()) >> 22) % (1u32 << 5);
     out = out.offset(1);
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack6_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 6);
+    *out = (in_buf.read_unaligned()) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 6) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 18) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 18) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 24) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 24) % (1u32 << 6);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (6 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (6 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 10) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 22) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 22) % (1u32 << 6);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (6 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (6 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 6);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 6);
+    *out = (in_buf.read_unaligned()) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 6) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 18) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 18) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 24) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 24) % (1u32 << 6);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (6 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (6 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 10) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 22) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 22) % (1u32 << 6);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (6 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (6 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 6);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 6);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 6);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack7_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 7);
+    *out = (in_buf.read_unaligned()) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 7) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 7) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 21) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 21) % (1u32 << 7);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (7 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (7 - 3);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 3) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 3) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 10) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 17) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 17) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 24) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 24) % (1u32 << 7);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (7 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (7 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 13) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 13) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 7);
     out = out.offset(1);
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (7 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (7 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 9) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 9) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 23) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 23) % (1u32 << 7);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 5)) << (7 - 5);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 5)) << (7 - 5);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 5) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 5) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 19) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 19) % (1u32 << 7);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (7 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (7 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 15) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 15) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 22) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 22) % (1u32 << 7);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (7 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (7 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 11) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 11) % (1u32 << 7);
     out = out.offset(1);
-    *out = ((*in_buf) >> 18) % (1u32 << 7);
+    *out = ((in_buf.read_unaligned()) >> 18) % (1u32 << 7);
     out = out.offset(1);
-    *out = (*in_buf) >> 25;
+    *out = (in_buf.read_unaligned()) >> 25;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack8_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 8);
+    *out = (in_buf.read_unaligned()) % (1u32 << 8);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 8);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 8);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 8);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 8);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
-    out = out.offset(1);
-    in_buf = in_buf.offset(1);
-
-    *out = (*in_buf) % (1u32 << 8);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 8);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 8);
-    out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 8);
+    *out = (in_buf.read_unaligned()) % (1u32 << 8);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 8);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 8);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 8);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 8);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
-    out = out.offset(1);
-    in_buf = in_buf.offset(1);
-
-    *out = (*in_buf) % (1u32 << 8);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 8);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 8);
-    out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 8);
+    *out = (in_buf.read_unaligned()) % (1u32 << 8);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 8);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 8);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 8);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 8);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
-    out = out.offset(1);
-    in_buf = in_buf.offset(1);
-
-    *out = (*in_buf) % (1u32 << 8);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 8);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 8);
-    out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 8);
+    *out = (in_buf.read_unaligned()) % (1u32 << 8);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 8);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 8);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 8);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 8);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 8);
+    *out = (in_buf.read_unaligned()) % (1u32 << 8);
     out = out.offset(1);
-    *out = ((*in_buf) >> 8) % (1u32 << 8);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 8);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 8);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 8);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
+    out = out.offset(1);
+    in_buf = in_buf.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 8);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 8);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 8);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 24;
+    out = out.offset(1);
+    in_buf = in_buf.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 8);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 8);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 8);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 24;
+    out = out.offset(1);
+    in_buf = in_buf.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 8);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 8);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 8);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 24;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack9_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 9);
+    *out = (in_buf.read_unaligned()) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 9) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 9) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 18) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 18) % (1u32 << 9);
     out = out.offset(1);
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (9 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (9 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 13) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 13) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 22) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 22) % (1u32 << 9);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (9 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (9 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 17) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 17) % (1u32 << 9);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (9 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (9 - 3);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 3) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 3) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 21) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 21) % (1u32 << 9);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 7)) << (9 - 7);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 7)) << (9 - 7);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 7) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 7) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 9);
     out = out.offset(1);
-    *out = (*in_buf) >> 25;
+    *out = (in_buf.read_unaligned()) >> 25;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (9 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (9 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 11) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 11) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 9);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (9 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (9 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 15) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 15) % (1u32 << 9);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (9 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (9 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 10) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 19) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 19) % (1u32 << 9);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 5)) << (9 - 5);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 5)) << (9 - 5);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 5) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 5) % (1u32 << 9);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 9);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 9);
     out = out.offset(1);
-    *out = (*in_buf) >> 23;
+    *out = (in_buf.read_unaligned()) >> 23;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack10_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 10);
+    *out = (in_buf.read_unaligned()) % (1u32 << 10);
     out = out.offset(1);
-    *out = ((*in_buf) >> 10) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 10);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 10);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (10 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (10 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 10);
     out = out.offset(1);
-    *out = ((*in_buf) >> 18) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 18) % (1u32 << 10);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (10 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (10 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 10);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 10);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (10 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (10 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 10);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 10);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (10 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (10 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 10);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 10);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 10);
+    *out = (in_buf.read_unaligned()) % (1u32 << 10);
     out = out.offset(1);
-    *out = ((*in_buf) >> 10) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 10);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 10);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (10 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (10 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 10);
     out = out.offset(1);
-    *out = ((*in_buf) >> 18) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 18) % (1u32 << 10);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (10 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (10 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 10);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 10);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (10 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (10 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 10);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 10);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (10 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (10 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 10);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 10);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 10);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack11_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 11);
+    *out = (in_buf.read_unaligned()) % (1u32 << 11);
     out = out.offset(1);
-    *out = ((*in_buf) >> 11) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 11) % (1u32 << 11);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (11 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (11 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 11);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 11);
     out = out.offset(1);
-    *out = (*in_buf) >> 23;
+    *out = (in_buf.read_unaligned()) >> 23;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (11 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (11 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 11);
     out = out.offset(1);
-    *out = ((*in_buf) >> 13) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 13) % (1u32 << 11);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (11 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (11 - 3);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 3) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 3) % (1u32 << 11);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 11);
     out = out.offset(1);
-    *out = (*in_buf) >> 25;
+    *out = (in_buf.read_unaligned()) >> 25;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (11 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (11 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 11);
     out = out.offset(1);
-    *out = ((*in_buf) >> 15) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 15) % (1u32 << 11);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 5)) << (11 - 5);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 5)) << (11 - 5);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 5) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 5) % (1u32 << 11);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 11);
     out = out.offset(1);
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (11 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (11 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 11);
     out = out.offset(1);
-    *out = ((*in_buf) >> 17) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 17) % (1u32 << 11);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 7)) << (11 - 7);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 7)) << (11 - 7);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 7) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 7) % (1u32 << 11);
     out = out.offset(1);
-    *out = ((*in_buf) >> 18) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 18) % (1u32 << 11);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (11 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (11 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 11);
     out = out.offset(1);
-    *out = ((*in_buf) >> 19) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 19) % (1u32 << 11);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 9)) << (11 - 9);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 9)) << (11 - 9);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 9) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 9) % (1u32 << 11);
     out = out.offset(1);
-    *out = ((*in_buf) >> 20) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 20) % (1u32 << 11);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (11 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (11 - 10);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 10) % (1u32 << 11);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 11);
     out = out.offset(1);
-    *out = (*in_buf) >> 21;
+    *out = (in_buf.read_unaligned()) >> 21;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack12_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 12);
+    *out = (in_buf.read_unaligned()) % (1u32 << 12);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 12);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 12);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (12 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (12 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 12);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 12);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 12);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 12);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (12 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (12 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 12);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 12);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
-    in_buf = in_buf.offset(1);
-    out = out.offset(1);
-
-    *out = (*in_buf) % (1u32 << 12);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 12);
-    out = out.offset(1);
-    *out = (*in_buf) >> 24;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (12 - 4);
-    out = out.offset(1);
-
-    *out = ((*in_buf) >> 4) % (1u32 << 12);
-    out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 12);
-    out = out.offset(1);
-    *out = (*in_buf) >> 28;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (12 - 8);
-    out = out.offset(1);
-
-    *out = ((*in_buf) >> 8) % (1u32 << 12);
-    out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 12);
+    *out = (in_buf.read_unaligned()) % (1u32 << 12);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 12);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 12);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (12 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (12 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 12);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 12);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 12);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 12);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (12 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (12 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 12);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 12);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 12);
+    *out = (in_buf.read_unaligned()) % (1u32 << 12);
     out = out.offset(1);
-    *out = ((*in_buf) >> 12) % (1u32 << 12);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 12);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (12 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (12 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 12);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 12);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 12);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 12);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (12 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (12 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 12);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 12);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
+    in_buf = in_buf.offset(1);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 12);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 12);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 24;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (12 - 4);
+    out = out.offset(1);
+
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 12);
+    out = out.offset(1);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 12);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 28;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (12 - 8);
+    out = out.offset(1);
+
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 12);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 20;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack13_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 13);
+    *out = (in_buf.read_unaligned()) % (1u32 << 13);
     out = out.offset(1);
-    *out = ((*in_buf) >> 13) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 13) % (1u32 << 13);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 7)) << (13 - 7);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 7)) << (13 - 7);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 7) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 7) % (1u32 << 13);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (13 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (13 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 13);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 13);
     out = out.offset(1);
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (13 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (13 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 13);
     out = out.offset(1);
-    *out = (*in_buf) >> 21;
+    *out = (in_buf.read_unaligned()) >> 21;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (13 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (13 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 13);
     out = out.offset(1);
-    *out = ((*in_buf) >> 15) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 15) % (1u32 << 13);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 9)) << (13 - 9);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 9)) << (13 - 9);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 9) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 9) % (1u32 << 13);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (13 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (13 - 3);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 3) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 3) % (1u32 << 13);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 13);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (13 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (13 - 10);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 10) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 13);
     out = out.offset(1);
-    *out = (*in_buf) >> 23;
+    *out = (in_buf.read_unaligned()) >> 23;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (13 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (13 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 13);
     out = out.offset(1);
-    *out = ((*in_buf) >> 17) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 17) % (1u32 << 13);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 11)) << (13 - 11);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 11)) << (13 - 11);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 11) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 11) % (1u32 << 13);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 5)) << (13 - 5);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 5)) << (13 - 5);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 5) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 5) % (1u32 << 13);
     out = out.offset(1);
-    *out = ((*in_buf) >> 18) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 18) % (1u32 << 13);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (13 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (13 - 12);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 12) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 13);
     out = out.offset(1);
-    *out = (*in_buf) >> 25;
+    *out = (in_buf.read_unaligned()) >> 25;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (13 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (13 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 13);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 13);
     out = out.offset(1);
-    *out = (*in_buf) >> 19;
+    *out = (in_buf.read_unaligned()) >> 19;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack14_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 14);
+    *out = (in_buf.read_unaligned()) % (1u32 << 14);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (14 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (14 - 10);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 10) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (14 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (14 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (14 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (14 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 14);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (14 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (14 - 12);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 12) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (14 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (14 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (14 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (14 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 14);
+    *out = (in_buf.read_unaligned()) % (1u32 << 14);
     out = out.offset(1);
-    *out = ((*in_buf) >> 14) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (14 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (14 - 10);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 10) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (14 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (14 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (14 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (14 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 14);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (14 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (14 - 12);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 12) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (14 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (14 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (14 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (14 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 14);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 14);
     out = out.offset(1);
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack15_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 15);
+    *out = (in_buf.read_unaligned()) % (1u32 << 15);
     out = out.offset(1);
-    *out = ((*in_buf) >> 15) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 15) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 13)) << (15 - 13);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 13)) << (15 - 13);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 13) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 13) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 11)) << (15 - 11);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 11)) << (15 - 11);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 11) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 11) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 9)) << (15 - 9);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 9)) << (15 - 9);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 9) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 9) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 7)) << (15 - 7);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 7)) << (15 - 7);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 7) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 7) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 5)) << (15 - 5);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 5)) << (15 - 5);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 5) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 5) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (15 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (15 - 3);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 3) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 3) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (15 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (15 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 15);
     out = out.offset(1);
-    *out = ((*in_buf) >> 16) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 16) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (15 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (15 - 14);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 14) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (15 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (15 - 12);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 12) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (15 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (15 - 10);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 10) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 25;
+    *out = (in_buf.read_unaligned()) >> 25;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (15 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (15 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 23;
+    *out = (in_buf.read_unaligned()) >> 23;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (15 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (15 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 21;
+    *out = (in_buf.read_unaligned()) >> 21;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (15 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (15 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 19;
+    *out = (in_buf.read_unaligned()) >> 19;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (15 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (15 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 15);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 15);
     out = out.offset(1);
-    *out = (*in_buf) >> 17;
+    *out = (in_buf.read_unaligned()) >> 17;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack16_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 16);
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
     out = out.offset(1);
-    *out = (*in_buf) >> 16;
-    out = out.offset(1);
-    in_buf = in_buf.offset(1);
-
-    *out = (*in_buf) % (1u32 << 16);
-    out = out.offset(1);
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 16);
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
     out = out.offset(1);
-    *out = (*in_buf) >> 16;
-    out = out.offset(1);
-    in_buf = in_buf.offset(1);
-
-    *out = (*in_buf) % (1u32 << 16);
-    out = out.offset(1);
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 16);
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
     out = out.offset(1);
-    *out = (*in_buf) >> 16;
-    out = out.offset(1);
-    in_buf = in_buf.offset(1);
-
-    *out = (*in_buf) % (1u32 << 16);
-    out = out.offset(1);
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 16);
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
     out = out.offset(1);
-    *out = (*in_buf) >> 16;
-    out = out.offset(1);
-    in_buf = in_buf.offset(1);
-
-    *out = (*in_buf) % (1u32 << 16);
-    out = out.offset(1);
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 16);
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
     out = out.offset(1);
-    *out = (*in_buf) >> 16;
-    out = out.offset(1);
-    in_buf = in_buf.offset(1);
-
-    *out = (*in_buf) % (1u32 << 16);
-    out = out.offset(1);
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 16);
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
     out = out.offset(1);
-    *out = (*in_buf) >> 16;
-    out = out.offset(1);
-    in_buf = in_buf.offset(1);
-
-    *out = (*in_buf) % (1u32 << 16);
-    out = out.offset(1);
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 16);
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
     out = out.offset(1);
-    *out = (*in_buf) >> 16;
-    out = out.offset(1);
-    in_buf = in_buf.offset(1);
-
-    *out = (*in_buf) % (1u32 << 16);
-    out = out.offset(1);
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 16);
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
     out = out.offset(1);
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     out = out.offset(1);
     in_buf = in_buf.offset(1);
 
-    *out = (*in_buf) % (1u32 << 16);
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
     out = out.offset(1);
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
+    out = out.offset(1);
+    in_buf = in_buf.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 16;
+    out = out.offset(1);
+    in_buf = in_buf.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 16;
+    out = out.offset(1);
+    in_buf = in_buf.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 16;
+    out = out.offset(1);
+    in_buf = in_buf.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 16;
+    out = out.offset(1);
+    in_buf = in_buf.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 16;
+    out = out.offset(1);
+    in_buf = in_buf.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 16;
+    out = out.offset(1);
+    in_buf = in_buf.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 16);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 16;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack17_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 17);
+    *out = (in_buf.read_unaligned()) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 17;
+    *out = (in_buf.read_unaligned()) >> 17;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (17 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (17 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 19;
+    *out = (in_buf.read_unaligned()) >> 19;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (17 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (17 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 21;
+    *out = (in_buf.read_unaligned()) >> 21;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (17 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (17 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 23;
+    *out = (in_buf.read_unaligned()) >> 23;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (17 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (17 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 25;
+    *out = (in_buf.read_unaligned()) >> 25;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (17 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (17 - 10);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 10) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (17 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (17 - 12);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 12) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (17 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (17 - 14);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 14) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 14) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (17 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (17 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (17 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (17 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (17 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (17 - 3);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 3) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 3) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 5)) << (17 - 5);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 5)) << (17 - 5);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 5) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 5) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 7)) << (17 - 7);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 7)) << (17 - 7);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 7) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 7) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 9)) << (17 - 9);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 9)) << (17 - 9);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 9) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 9) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 11)) << (17 - 11);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 11)) << (17 - 11);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 11) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 11) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 13)) << (17 - 13);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 13)) << (17 - 13);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 13) % (1u32 << 17);
+    *out = ((in_buf.read_unaligned()) >> 13) % (1u32 << 17);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 15)) << (17 - 15);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 15)) << (17 - 15);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 15;
+    *out = (in_buf.read_unaligned()) >> 15;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack18_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 18);
+    *out = (in_buf.read_unaligned()) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (18 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (18 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 18);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (18 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (18 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 18);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (18 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (18 - 12);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 12) % (1u32 << 18);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (18 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (18 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (18 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (18 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 18);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (18 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (18 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 18);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (18 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (18 - 10);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 10) % (1u32 << 18);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (18 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (18 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 18);
+    *out = (in_buf.read_unaligned()) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (18 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (18 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 18);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (18 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (18 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 18);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (18 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (18 - 12);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 12) % (1u32 << 18);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (18 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (18 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (18 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (18 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 18);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (18 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (18 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 18);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (18 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (18 - 10);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 10) % (1u32 << 18);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 18);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (18 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (18 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack19_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 19);
+    *out = (in_buf.read_unaligned()) % (1u32 << 19);
     out = out.offset(1);
-    *out = (*in_buf) >> 19;
+    *out = (in_buf.read_unaligned()) >> 19;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (19 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (19 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 19);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 19);
     out = out.offset(1);
-    *out = (*in_buf) >> 25;
+    *out = (in_buf.read_unaligned()) >> 25;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (19 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (19 - 12);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 12) % (1u32 << 19);
+    *out = ((in_buf.read_unaligned()) >> 12) % (1u32 << 19);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 18)) << (19 - 18);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 18)) << (19 - 18);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 5)) << (19 - 5);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 5)) << (19 - 5);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 5) % (1u32 << 19);
+    *out = ((in_buf.read_unaligned()) >> 5) % (1u32 << 19);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 11)) << (19 - 11);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 11)) << (19 - 11);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 11) % (1u32 << 19);
+    *out = ((in_buf.read_unaligned()) >> 11) % (1u32 << 19);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 17)) << (19 - 17);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 17)) << (19 - 17);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 17;
+    *out = (in_buf.read_unaligned()) >> 17;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (19 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (19 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 19);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 19);
     out = out.offset(1);
-    *out = (*in_buf) >> 23;
+    *out = (in_buf.read_unaligned()) >> 23;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (19 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (19 - 10);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 10) % (1u32 << 19);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 19);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (19 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (19 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (19 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (19 - 3);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 3) % (1u32 << 19);
+    *out = ((in_buf.read_unaligned()) >> 3) % (1u32 << 19);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 9)) << (19 - 9);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 9)) << (19 - 9);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 9) % (1u32 << 19);
+    *out = ((in_buf.read_unaligned()) >> 9) % (1u32 << 19);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 15)) << (19 - 15);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 15)) << (19 - 15);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 15;
+    *out = (in_buf.read_unaligned()) >> 15;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (19 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (19 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 19);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 19);
     out = out.offset(1);
-    *out = (*in_buf) >> 21;
+    *out = (in_buf.read_unaligned()) >> 21;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (19 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (19 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 19);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 19);
     out = out.offset(1);
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (19 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (19 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (19 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (19 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 19);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 19);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 7)) << (19 - 7);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 7)) << (19 - 7);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 7) % (1u32 << 19);
+    *out = ((in_buf.read_unaligned()) >> 7) % (1u32 << 19);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 13)) << (19 - 13);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 13)) << (19 - 13);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 13;
+    *out = (in_buf.read_unaligned()) >> 13;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack20_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 20);
+    *out = (in_buf.read_unaligned()) % (1u32 << 20);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (20 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (20 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 20);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 20);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (20 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (20 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (20 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (20 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 20);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 20);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (20 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (20 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
-    in_buf = in_buf.offset(1);
-    out = out.offset(1);
-
-    *out = (*in_buf) % (1u32 << 20);
-    out = out.offset(1);
-    *out = (*in_buf) >> 20;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (20 - 8);
-    out = out.offset(1);
-
-    *out = ((*in_buf) >> 8) % (1u32 << 20);
-    out = out.offset(1);
-    *out = (*in_buf) >> 28;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (20 - 16);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 16;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (20 - 4);
-    out = out.offset(1);
-
-    *out = ((*in_buf) >> 4) % (1u32 << 20);
-    out = out.offset(1);
-    *out = (*in_buf) >> 24;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (20 - 12);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 20);
+    *out = (in_buf.read_unaligned()) % (1u32 << 20);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (20 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (20 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 20);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 20);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (20 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (20 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (20 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (20 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 20);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 20);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (20 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (20 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 20);
+    *out = (in_buf.read_unaligned()) % (1u32 << 20);
     out = out.offset(1);
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (20 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (20 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 20);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 20);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (20 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (20 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (20 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (20 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 20);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 20);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (20 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (20 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
+    in_buf = in_buf.offset(1);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 20);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 20;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (20 - 8);
+    out = out.offset(1);
+
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 20);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 28;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (20 - 16);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 16;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (20 - 4);
+    out = out.offset(1);
+
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 20);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 24;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (20 - 12);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 12;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack21_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 21);
+    *out = (in_buf.read_unaligned()) % (1u32 << 21);
     out = out.offset(1);
-    *out = (*in_buf) >> 21;
+    *out = (in_buf.read_unaligned()) >> 21;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (21 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (21 - 10);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 10) % (1u32 << 21);
+    *out = ((in_buf.read_unaligned()) >> 10) % (1u32 << 21);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (21 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (21 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 9)) << (21 - 9);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 9)) << (21 - 9);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 9) % (1u32 << 21);
+    *out = ((in_buf.read_unaligned()) >> 9) % (1u32 << 21);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 19)) << (21 - 19);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 19)) << (21 - 19);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 19;
+    *out = (in_buf.read_unaligned()) >> 19;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (21 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (21 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 21);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 21);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 18)) << (21 - 18);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 18)) << (21 - 18);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 7)) << (21 - 7);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 7)) << (21 - 7);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 7) % (1u32 << 21);
+    *out = ((in_buf.read_unaligned()) >> 7) % (1u32 << 21);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 17)) << (21 - 17);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 17)) << (21 - 17);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 17;
+    *out = (in_buf.read_unaligned()) >> 17;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (21 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (21 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 21);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 21);
     out = out.offset(1);
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (21 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (21 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 5)) << (21 - 5);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 5)) << (21 - 5);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 5) % (1u32 << 21);
+    *out = ((in_buf.read_unaligned()) >> 5) % (1u32 << 21);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 15)) << (21 - 15);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 15)) << (21 - 15);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 15;
+    *out = (in_buf.read_unaligned()) >> 15;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (21 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (21 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 21);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 21);
     out = out.offset(1);
-    *out = (*in_buf) >> 25;
+    *out = (in_buf.read_unaligned()) >> 25;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (21 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (21 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (21 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (21 - 3);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 3) % (1u32 << 21);
+    *out = ((in_buf.read_unaligned()) >> 3) % (1u32 << 21);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 13)) << (21 - 13);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 13)) << (21 - 13);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 13;
+    *out = (in_buf.read_unaligned()) >> 13;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (21 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (21 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 21);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 21);
     out = out.offset(1);
-    *out = (*in_buf) >> 23;
+    *out = (in_buf.read_unaligned()) >> 23;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (21 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (21 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (21 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (21 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 21);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 21);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 11)) << (21 - 11);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 11)) << (21 - 11);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 11;
+    *out = (in_buf.read_unaligned()) >> 11;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack22_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 22);
+    *out = (in_buf.read_unaligned()) % (1u32 << 22);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (22 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (22 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (22 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (22 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 22);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 22);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (22 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (22 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (22 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (22 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 22);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 22);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (22 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (22 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (22 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (22 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 22);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 22);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 18)) << (22 - 18);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 18)) << (22 - 18);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (22 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (22 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 22);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 22);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (22 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (22 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (22 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (22 - 10);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 10;
+    *out = (in_buf.read_unaligned()) >> 10;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 22);
+    *out = (in_buf.read_unaligned()) % (1u32 << 22);
     out = out.offset(1);
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (22 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (22 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (22 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (22 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 22);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 22);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (22 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (22 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (22 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (22 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 22);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 22);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (22 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (22 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (22 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (22 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 22);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 22);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 18)) << (22 - 18);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 18)) << (22 - 18);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (22 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (22 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 22);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 22);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (22 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (22 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (22 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (22 - 10);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 10;
+    *out = (in_buf.read_unaligned()) >> 10;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack23_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 23);
+    *out = (in_buf.read_unaligned()) % (1u32 << 23);
     out = out.offset(1);
-    *out = (*in_buf) >> 23;
+    *out = (in_buf.read_unaligned()) >> 23;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (23 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (23 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 5)) << (23 - 5);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 5)) << (23 - 5);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 5) % (1u32 << 23);
+    *out = ((in_buf.read_unaligned()) >> 5) % (1u32 << 23);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 19)) << (23 - 19);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 19)) << (23 - 19);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 19;
+    *out = (in_buf.read_unaligned()) >> 19;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (23 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (23 - 10);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 10;
+    *out = (in_buf.read_unaligned()) >> 10;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (23 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (23 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 23);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 23);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 15)) << (23 - 15);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 15)) << (23 - 15);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 15;
+    *out = (in_buf.read_unaligned()) >> 15;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (23 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (23 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 23);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 23);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (23 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (23 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 11)) << (23 - 11);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 11)) << (23 - 11);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 11;
+    *out = (in_buf.read_unaligned()) >> 11;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (23 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (23 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 23);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 23);
     out = out.offset(1);
-    *out = (*in_buf) >> 25;
+    *out = (in_buf.read_unaligned()) >> 25;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (23 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (23 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 7)) << (23 - 7);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 7)) << (23 - 7);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 7) % (1u32 << 23);
+    *out = ((in_buf.read_unaligned()) >> 7) % (1u32 << 23);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 21)) << (23 - 21);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 21)) << (23 - 21);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 21;
+    *out = (in_buf.read_unaligned()) >> 21;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (23 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (23 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (23 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (23 - 3);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 3) % (1u32 << 23);
+    *out = ((in_buf.read_unaligned()) >> 3) % (1u32 << 23);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 17)) << (23 - 17);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 17)) << (23 - 17);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 17;
+    *out = (in_buf.read_unaligned()) >> 17;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (23 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (23 - 8);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 8) % (1u32 << 23);
+    *out = ((in_buf.read_unaligned()) >> 8) % (1u32 << 23);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 22)) << (23 - 22);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 22)) << (23 - 22);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 13)) << (23 - 13);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 13)) << (23 - 13);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 13;
+    *out = (in_buf.read_unaligned()) >> 13;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (23 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (23 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 23);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 23);
     out = out.offset(1);
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 18)) << (23 - 18);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 18)) << (23 - 18);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 9)) << (23 - 9);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 9)) << (23 - 9);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 9;
+    *out = (in_buf.read_unaligned()) >> 9;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack24_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 24);
+    *out = (in_buf.read_unaligned()) % (1u32 << 24);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (24 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (24 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (24 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (24 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
-    in_buf = in_buf.offset(1);
-    out = out.offset(1);
-
-    *out = (*in_buf) % (1u32 << 24);
-    out = out.offset(1);
-    *out = (*in_buf) >> 24;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (24 - 16);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 16;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (24 - 8);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 24);
+    *out = (in_buf.read_unaligned()) % (1u32 << 24);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (24 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (24 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (24 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (24 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
-    in_buf = in_buf.offset(1);
-    out = out.offset(1);
-
-    *out = (*in_buf) % (1u32 << 24);
-    out = out.offset(1);
-    *out = (*in_buf) >> 24;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (24 - 16);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 16;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (24 - 8);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 24);
+    *out = (in_buf.read_unaligned()) % (1u32 << 24);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (24 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (24 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (24 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (24 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
-    in_buf = in_buf.offset(1);
-    out = out.offset(1);
-
-    *out = (*in_buf) % (1u32 << 24);
-    out = out.offset(1);
-    *out = (*in_buf) >> 24;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (24 - 16);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 16;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (24 - 8);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 24);
+    *out = (in_buf.read_unaligned()) % (1u32 << 24);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (24 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (24 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (24 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (24 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 24);
+    *out = (in_buf.read_unaligned()) % (1u32 << 24);
     out = out.offset(1);
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (24 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (24 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (24 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (24 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
+    in_buf = in_buf.offset(1);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 24);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 24;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (24 - 16);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 16;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (24 - 8);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 8;
+    in_buf = in_buf.offset(1);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 24);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 24;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (24 - 16);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 16;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (24 - 8);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 8;
+    in_buf = in_buf.offset(1);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 24);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 24;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (24 - 16);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 16;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (24 - 8);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 8;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack25_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 25);
+    *out = (in_buf.read_unaligned()) % (1u32 << 25);
     out = out.offset(1);
-    *out = (*in_buf) >> 25;
+    *out = (in_buf.read_unaligned()) >> 25;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 18)) << (25 - 18);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 18)) << (25 - 18);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 11)) << (25 - 11);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 11)) << (25 - 11);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 11;
+    *out = (in_buf.read_unaligned()) >> 11;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (25 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (25 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 25);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 25);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 22)) << (25 - 22);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 22)) << (25 - 22);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 15)) << (25 - 15);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 15)) << (25 - 15);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 15;
+    *out = (in_buf.read_unaligned()) >> 15;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (25 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (25 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (25 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (25 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 25);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 25);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 19)) << (25 - 19);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 19)) << (25 - 19);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 19;
+    *out = (in_buf.read_unaligned()) >> 19;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (25 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (25 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 5)) << (25 - 5);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 5)) << (25 - 5);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 5) % (1u32 << 25);
+    *out = ((in_buf.read_unaligned()) >> 5) % (1u32 << 25);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 23)) << (25 - 23);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 23)) << (25 - 23);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 23;
+    *out = (in_buf.read_unaligned()) >> 23;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (25 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (25 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 9)) << (25 - 9);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 9)) << (25 - 9);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 9;
+    *out = (in_buf.read_unaligned()) >> 9;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (25 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (25 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 25);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 25);
     out = out.offset(1);
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (25 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (25 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 13)) << (25 - 13);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 13)) << (25 - 13);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 13;
+    *out = (in_buf.read_unaligned()) >> 13;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (25 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (25 - 6);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 6) % (1u32 << 25);
+    *out = ((in_buf.read_unaligned()) >> 6) % (1u32 << 25);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 24)) << (25 - 24);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 24)) << (25 - 24);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 17)) << (25 - 17);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 17)) << (25 - 17);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 17;
+    *out = (in_buf.read_unaligned()) >> 17;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (25 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (25 - 10);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 10;
+    *out = (in_buf.read_unaligned()) >> 10;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (25 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (25 - 3);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 3) % (1u32 << 25);
+    *out = ((in_buf.read_unaligned()) >> 3) % (1u32 << 25);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 21)) << (25 - 21);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 21)) << (25 - 21);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 21;
+    *out = (in_buf.read_unaligned()) >> 21;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (25 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (25 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 7)) << (25 - 7);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 7)) << (25 - 7);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 7;
+    *out = (in_buf.read_unaligned()) >> 7;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack26_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 26);
+    *out = (in_buf.read_unaligned()) % (1u32 << 26);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (26 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (26 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (26 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (26 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (26 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (26 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (26 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (26 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 26);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 26);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 22)) << (26 - 22);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 22)) << (26 - 22);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (26 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (26 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (26 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (26 - 10);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 10;
+    *out = (in_buf.read_unaligned()) >> 10;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (26 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (26 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 26);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 26);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 24)) << (26 - 24);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 24)) << (26 - 24);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 18)) << (26 - 18);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 18)) << (26 - 18);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (26 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (26 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (26 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (26 - 6);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 6;
+    *out = (in_buf.read_unaligned()) >> 6;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 26);
+    *out = (in_buf.read_unaligned()) % (1u32 << 26);
     out = out.offset(1);
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (26 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (26 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (26 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (26 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (26 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (26 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (26 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (26 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 26);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 26);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 22)) << (26 - 22);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 22)) << (26 - 22);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (26 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (26 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (26 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (26 - 10);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 10;
+    *out = (in_buf.read_unaligned()) >> 10;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (26 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (26 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 26);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 26);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 24)) << (26 - 24);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 24)) << (26 - 24);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 18)) << (26 - 18);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 18)) << (26 - 18);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (26 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (26 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (26 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (26 - 6);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 6;
+    *out = (in_buf.read_unaligned()) >> 6;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack27_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 27);
+    *out = (in_buf.read_unaligned()) % (1u32 << 27);
     out = out.offset(1);
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 22)) << (27 - 22);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 22)) << (27 - 22);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 17)) << (27 - 17);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 17)) << (27 - 17);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 17;
+    *out = (in_buf.read_unaligned()) >> 17;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (27 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (27 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 7)) << (27 - 7);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 7)) << (27 - 7);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 7;
+    *out = (in_buf.read_unaligned()) >> 7;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (27 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (27 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 27);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 27);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 24)) << (27 - 24);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 24)) << (27 - 24);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 19)) << (27 - 19);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 19)) << (27 - 19);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 19;
+    *out = (in_buf.read_unaligned()) >> 19;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (27 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (27 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 9)) << (27 - 9);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 9)) << (27 - 9);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 9;
+    *out = (in_buf.read_unaligned()) >> 9;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (27 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (27 - 4);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 4) % (1u32 << 27);
+    *out = ((in_buf.read_unaligned()) >> 4) % (1u32 << 27);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 26)) << (27 - 26);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 26)) << (27 - 26);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 21)) << (27 - 21);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 21)) << (27 - 21);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 21;
+    *out = (in_buf.read_unaligned()) >> 21;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (27 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (27 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 11)) << (27 - 11);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 11)) << (27 - 11);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 11;
+    *out = (in_buf.read_unaligned()) >> 11;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (27 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (27 - 6);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 6;
+    *out = (in_buf.read_unaligned()) >> 6;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (27 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (27 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 27);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 27);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 23)) << (27 - 23);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 23)) << (27 - 23);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 23;
+    *out = (in_buf.read_unaligned()) >> 23;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 18)) << (27 - 18);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 18)) << (27 - 18);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 13)) << (27 - 13);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 13)) << (27 - 13);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 13;
+    *out = (in_buf.read_unaligned()) >> 13;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (27 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (27 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (27 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (27 - 3);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 3) % (1u32 << 27);
+    *out = ((in_buf.read_unaligned()) >> 3) % (1u32 << 27);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 25)) << (27 - 25);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 25)) << (27 - 25);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 25;
+    *out = (in_buf.read_unaligned()) >> 25;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (27 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (27 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 15)) << (27 - 15);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 15)) << (27 - 15);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 15;
+    *out = (in_buf.read_unaligned()) >> 15;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (27 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (27 - 10);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 10;
+    *out = (in_buf.read_unaligned()) >> 10;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 5)) << (27 - 5);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 5)) << (27 - 5);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 5;
+    *out = (in_buf.read_unaligned()) >> 5;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack28_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 28);
+    *out = (in_buf.read_unaligned()) % (1u32 << 28);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 24)) << (28 - 24);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 24)) << (28 - 24);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (28 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (28 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (28 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (28 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (28 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (28 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (28 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (28 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (28 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (28 - 4);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 4;
-    in_buf = in_buf.offset(1);
-    out = out.offset(1);
-
-    *out = (*in_buf) % (1u32 << 28);
-    out = out.offset(1);
-    *out = (*in_buf) >> 28;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 24)) << (28 - 24);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 24;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (28 - 20);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 20;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (28 - 16);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 16;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (28 - 12);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 12;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (28 - 8);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 8;
-    in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (28 - 4);
-    out = out.offset(1);
-
-    *out = (*in_buf) >> 4;
+    *out = (in_buf.read_unaligned()) >> 4;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 28);
+    *out = (in_buf.read_unaligned()) % (1u32 << 28);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 24)) << (28 - 24);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 24)) << (28 - 24);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (28 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (28 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (28 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (28 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (28 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (28 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (28 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (28 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (28 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (28 - 4);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 4;
+    *out = (in_buf.read_unaligned()) >> 4;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 28);
+    *out = (in_buf.read_unaligned()) % (1u32 << 28);
     out = out.offset(1);
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 24)) << (28 - 24);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 24)) << (28 - 24);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (28 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (28 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (28 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (28 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (28 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (28 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (28 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (28 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (28 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (28 - 4);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 4;
+    *out = (in_buf.read_unaligned()) >> 4;
+    in_buf = in_buf.offset(1);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) % (1u32 << 28);
+    out = out.offset(1);
+    *out = (in_buf.read_unaligned()) >> 28;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 24)) << (28 - 24);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 24;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (28 - 20);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 20;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (28 - 16);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 16;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (28 - 12);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 12;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (28 - 8);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 8;
+    in_buf = in_buf.offset(1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (28 - 4);
+    out = out.offset(1);
+
+    *out = (in_buf.read_unaligned()) >> 4;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack29_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 29);
+    *out = (in_buf.read_unaligned()) % (1u32 << 29);
     out = out.offset(1);
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 26)) << (29 - 26);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 26)) << (29 - 26);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 23)) << (29 - 23);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 23)) << (29 - 23);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 23;
+    *out = (in_buf.read_unaligned()) >> 23;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (29 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (29 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 17)) << (29 - 17);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 17)) << (29 - 17);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 17;
+    *out = (in_buf.read_unaligned()) >> 17;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (29 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (29 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 11)) << (29 - 11);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 11)) << (29 - 11);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 11;
+    *out = (in_buf.read_unaligned()) >> 11;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (29 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (29 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 5)) << (29 - 5);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 5)) << (29 - 5);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 5;
+    *out = (in_buf.read_unaligned()) >> 5;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (29 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (29 - 2);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 2) % (1u32 << 29);
+    *out = ((in_buf.read_unaligned()) >> 2) % (1u32 << 29);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 28)) << (29 - 28);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 28)) << (29 - 28);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 25)) << (29 - 25);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 25)) << (29 - 25);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 25;
+    *out = (in_buf.read_unaligned()) >> 25;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 22)) << (29 - 22);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 22)) << (29 - 22);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 19)) << (29 - 19);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 19)) << (29 - 19);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 19;
+    *out = (in_buf.read_unaligned()) >> 19;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (29 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (29 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 13)) << (29 - 13);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 13)) << (29 - 13);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 13;
+    *out = (in_buf.read_unaligned()) >> 13;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (29 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (29 - 10);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 10;
+    *out = (in_buf.read_unaligned()) >> 10;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 7)) << (29 - 7);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 7)) << (29 - 7);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 7;
+    *out = (in_buf.read_unaligned()) >> 7;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (29 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (29 - 4);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 4;
+    *out = (in_buf.read_unaligned()) >> 4;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (29 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (29 - 1);
     out = out.offset(1);
 
-    *out = ((*in_buf) >> 1) % (1u32 << 29);
+    *out = ((in_buf.read_unaligned()) >> 1) % (1u32 << 29);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 27)) << (29 - 27);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 27)) << (29 - 27);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 24)) << (29 - 24);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 24)) << (29 - 24);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 21)) << (29 - 21);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 21)) << (29 - 21);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 21;
+    *out = (in_buf.read_unaligned()) >> 21;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 18)) << (29 - 18);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 18)) << (29 - 18);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 15)) << (29 - 15);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 15)) << (29 - 15);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 15;
+    *out = (in_buf.read_unaligned()) >> 15;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (29 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (29 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 9)) << (29 - 9);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 9)) << (29 - 9);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 9;
+    *out = (in_buf.read_unaligned()) >> 9;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (29 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (29 - 6);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 6;
+    *out = (in_buf.read_unaligned()) >> 6;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (29 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (29 - 3);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 3;
+    *out = (in_buf.read_unaligned()) >> 3;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack30_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 30);
+    *out = (in_buf.read_unaligned()) % (1u32 << 30);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 28)) << (30 - 28);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 28)) << (30 - 28);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 26)) << (30 - 26);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 26)) << (30 - 26);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 24)) << (30 - 24);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 24)) << (30 - 24);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 22)) << (30 - 22);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 22)) << (30 - 22);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (30 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (30 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 18)) << (30 - 18);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 18)) << (30 - 18);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (30 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (30 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (30 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (30 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (30 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (30 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (30 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (30 - 10);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 10;
+    *out = (in_buf.read_unaligned()) >> 10;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (30 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (30 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (30 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (30 - 6);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 6;
+    *out = (in_buf.read_unaligned()) >> 6;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (30 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (30 - 4);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 4;
+    *out = (in_buf.read_unaligned()) >> 4;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (30 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (30 - 2);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 2;
+    *out = (in_buf.read_unaligned()) >> 2;
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = (*in_buf) % (1u32 << 30);
+    *out = (in_buf.read_unaligned()) % (1u32 << 30);
     out = out.offset(1);
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 28)) << (30 - 28);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 28)) << (30 - 28);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 26)) << (30 - 26);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 26)) << (30 - 26);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 24)) << (30 - 24);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 24)) << (30 - 24);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 22)) << (30 - 22);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 22)) << (30 - 22);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (30 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (30 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 18)) << (30 - 18);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 18)) << (30 - 18);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (30 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (30 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (30 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (30 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (30 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (30 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (30 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (30 - 10);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 10;
+    *out = (in_buf.read_unaligned()) >> 10;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (30 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (30 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (30 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (30 - 6);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 6;
+    *out = (in_buf.read_unaligned()) >> 6;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (30 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (30 - 4);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 4;
+    *out = (in_buf.read_unaligned()) >> 4;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (30 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (30 - 2);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 2;
+    *out = (in_buf.read_unaligned()) >> 2;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack31_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = (*in_buf) % (1u32 << 31);
+    *out = (in_buf.read_unaligned()) % (1u32 << 31);
     out = out.offset(1);
-    *out = (*in_buf) >> 31;
+    *out = (in_buf.read_unaligned()) >> 31;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 30)) << (31 - 30);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 30)) << (31 - 30);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 30;
+    *out = (in_buf.read_unaligned()) >> 30;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 29)) << (31 - 29);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 29)) << (31 - 29);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 29;
+    *out = (in_buf.read_unaligned()) >> 29;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 28)) << (31 - 28);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 28)) << (31 - 28);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 28;
+    *out = (in_buf.read_unaligned()) >> 28;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 27)) << (31 - 27);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 27)) << (31 - 27);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 27;
+    *out = (in_buf.read_unaligned()) >> 27;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 26)) << (31 - 26);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 26)) << (31 - 26);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 26;
+    *out = (in_buf.read_unaligned()) >> 26;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 25)) << (31 - 25);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 25)) << (31 - 25);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 25;
+    *out = (in_buf.read_unaligned()) >> 25;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 24)) << (31 - 24);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 24)) << (31 - 24);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 24;
+    *out = (in_buf.read_unaligned()) >> 24;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 23)) << (31 - 23);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 23)) << (31 - 23);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 23;
+    *out = (in_buf.read_unaligned()) >> 23;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 22)) << (31 - 22);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 22)) << (31 - 22);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 22;
+    *out = (in_buf.read_unaligned()) >> 22;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 21)) << (31 - 21);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 21)) << (31 - 21);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 21;
+    *out = (in_buf.read_unaligned()) >> 21;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 20)) << (31 - 20);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 20)) << (31 - 20);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 20;
+    *out = (in_buf.read_unaligned()) >> 20;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 19)) << (31 - 19);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 19)) << (31 - 19);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 19;
+    *out = (in_buf.read_unaligned()) >> 19;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 18)) << (31 - 18);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 18)) << (31 - 18);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 18;
+    *out = (in_buf.read_unaligned()) >> 18;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 17)) << (31 - 17);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 17)) << (31 - 17);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 17;
+    *out = (in_buf.read_unaligned()) >> 17;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 16)) << (31 - 16);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 16)) << (31 - 16);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 16;
+    *out = (in_buf.read_unaligned()) >> 16;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 15)) << (31 - 15);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 15)) << (31 - 15);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 15;
+    *out = (in_buf.read_unaligned()) >> 15;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 14)) << (31 - 14);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 14)) << (31 - 14);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 14;
+    *out = (in_buf.read_unaligned()) >> 14;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 13)) << (31 - 13);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 13)) << (31 - 13);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 13;
+    *out = (in_buf.read_unaligned()) >> 13;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 12)) << (31 - 12);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 12)) << (31 - 12);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 12;
+    *out = (in_buf.read_unaligned()) >> 12;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 11)) << (31 - 11);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 11)) << (31 - 11);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 11;
+    *out = (in_buf.read_unaligned()) >> 11;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 10)) << (31 - 10);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 10)) << (31 - 10);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 10;
+    *out = (in_buf.read_unaligned()) >> 10;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 9)) << (31 - 9);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 9)) << (31 - 9);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 9;
+    *out = (in_buf.read_unaligned()) >> 9;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 8)) << (31 - 8);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 8)) << (31 - 8);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 8;
+    *out = (in_buf.read_unaligned()) >> 8;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 7)) << (31 - 7);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 7)) << (31 - 7);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 7;
+    *out = (in_buf.read_unaligned()) >> 7;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 6)) << (31 - 6);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 6)) << (31 - 6);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 6;
+    *out = (in_buf.read_unaligned()) >> 6;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 5)) << (31 - 5);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 5)) << (31 - 5);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 5;
+    *out = (in_buf.read_unaligned()) >> 5;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 4)) << (31 - 4);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 4)) << (31 - 4);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 4;
+    *out = (in_buf.read_unaligned()) >> 4;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 3)) << (31 - 3);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 3)) << (31 - 3);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 3;
+    *out = (in_buf.read_unaligned()) >> 3;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 2)) << (31 - 2);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 2)) << (31 - 2);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 2;
+    *out = (in_buf.read_unaligned()) >> 2;
     in_buf = in_buf.offset(1);
-    *out |= ((*in_buf) % (1u32 << 1)) << (31 - 1);
+    *out |= ((in_buf.read_unaligned()) % (1u32 << 1)) << (31 - 1);
     out = out.offset(1);
 
-    *out = (*in_buf) >> 1;
+    *out = (in_buf.read_unaligned()) >> 1;
 
     in_buf.offset(1)
 }
 
 unsafe fn unpack32_32(mut in_buf: *const u32, mut out: *mut u32) -> *const u32 {
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
     in_buf = in_buf.offset(1);
     out = out.offset(1);
 
-    *out = *in_buf;
+    *out = in_buf.read_unaligned();
 
     in_buf.offset(1)
 }

--- a/parquet/src/util/bit_util.rs
+++ b/parquet/src/util/bit_util.rs
@@ -553,7 +553,6 @@ impl BitReader {
         unsafe {
             let in_buf = &self.buffer.data()[self.byte_offset..];
             let mut in_ptr = in_buf as *const [u8] as *const u8 as *const u32;
-            // FIXME assert!(memory::is_ptr_aligned(in_ptr));
             if size_of::<T>() == 4 {
                 while values_to_read - i >= 32 {
                     let out_ptr = &mut batch[i..] as *mut [T] as *mut T as *mut u32;

--- a/parquet/src/util/hash_util.rs
+++ b/parquet/src/util/hash_util.rs
@@ -33,7 +33,12 @@ fn hash_(data: &[u8], seed: u32) -> u32 {
         }
     }
 
-    #[cfg(any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"))]
+    #[cfg(any(
+        target_arch = "aarch64",
+        target_arch = "arm",
+        target_arch = "riscv64",
+        target_arch = "wasm32"
+    ))]
     unsafe {
         murmur_hash2_64a(data, seed as u64) as u32
     }

--- a/parquet/src/util/hash_util.rs
+++ b/parquet/src/util/hash_util.rs
@@ -33,7 +33,7 @@ fn hash_(data: &[u8], seed: u32) -> u32 {
         }
     }
 
-    #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
+    #[cfg(any(target_arch = "aarch64", target_arch = "arm", target_arch = "riscv64"))]
     unsafe {
         murmur_hash2_64a(data, seed as u64) as u32
     }

--- a/parquet/src/util/hash_util.rs
+++ b/parquet/src/util/hash_util.rs
@@ -25,9 +25,9 @@ pub fn hash<T: AsBytes>(data: &T, seed: u32) -> u32 {
 
 fn hash_(data: &[u8], seed: u32) -> u32 {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    unsafe {
+    {
         if is_x86_feature_detected!("sse4.2") {
-            crc32_hash(data, seed)
+            unsafe { crc32_hash(data, seed) }
         } else {
             murmur_hash2_64a(data, seed as u64) as u32
         }
@@ -39,7 +39,7 @@ fn hash_(data: &[u8], seed: u32) -> u32 {
         target_arch = "riscv64",
         target_arch = "wasm32"
     ))]
-    unsafe {
+    {
         murmur_hash2_64a(data, seed as u64) as u32
     }
 }
@@ -48,19 +48,16 @@ const MURMUR_PRIME: u64 = 0xc6a4a7935bd1e995;
 const MURMUR_R: i32 = 47;
 
 /// Rust implementation of MurmurHash2, 64-bit version for 64-bit platforms
-///
-/// SAFTETY Only safe on platforms which support unaligned loads (like x86_64)
-unsafe fn murmur_hash2_64a(data_bytes: &[u8], seed: u64) -> u64 {
+fn murmur_hash2_64a(data_bytes: &[u8], seed: u64) -> u64 {
+    use std::convert::TryInto;
     let len = data_bytes.len();
     let len_64 = (len / 8) * 8;
-    let data_bytes_64 = std::slice::from_raw_parts(
-        &data_bytes[0..len_64] as *const [u8] as *const u64,
-        len / 8,
-    );
 
     let mut h = seed ^ (MURMUR_PRIME.wrapping_mul(data_bytes.len() as u64));
-    for v in data_bytes_64 {
-        let mut k = *v;
+    for mut k in data_bytes
+        .chunks_exact(8)
+        .map(|chunk| u64::from_ne_bytes(chunk.try_into().unwrap()))
+    {
         k = k.wrapping_mul(MURMUR_PRIME);
         k ^= k >> MURMUR_R;
         k = k.wrapping_mul(MURMUR_PRIME);
@@ -146,16 +143,14 @@ mod tests {
 
     #[test]
     fn test_murmur2_64a() {
-        unsafe {
-            let result = murmur_hash2_64a(b"hello", 123);
-            assert_eq!(result, 2597646618390559622);
+        let result = murmur_hash2_64a(b"hello", 123);
+        assert_eq!(result, 2597646618390559622);
 
-            let result = murmur_hash2_64a(b"helloworld", 123);
-            assert_eq!(result, 4934371746140206573);
+        let result = murmur_hash2_64a(b"helloworld", 123);
+        assert_eq!(result, 4934371746140206573);
 
-            let result = murmur_hash2_64a(b"helloworldparquet", 123);
-            assert_eq!(result, 2392198230801491746);
-        }
+        let result = murmur_hash2_64a(b"helloworldparquet", 123);
+        assert_eq!(result, 2392198230801491746);
     }
 
     #[test]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2024-01-29"


### PR DESCRIPTION
```
rustc 1.77.0-nightly (635124704 2024-01-27)
binary: rustc
commit-hash: 635124704849eeead4e3a7bb6e663c5351571d93
commit-date: 2024-01-27
host: aarch64-apple-darwin
release: 1.77.0-nightly
LLVM version: 17.0.6
```