### PR TITLE
feat: add ParquetEncryptionMode, to permit unencrypted files in initial key rotation

### DIFF
--- a/parquet/src/file/encryption.rs
+++ b/parquet/src/file/encryption.rs
@@ -46,7 +46,7 @@ pub enum ParquetEncryptionMode {
     Unencrypted,
     /// Means the file is encrypted with encrypted footer mode.  The same
     /// key is used for all the columns too, in this implementation.
-    FooterEncrypted(ParquetEncryptionKeyInfo),
+    EncryptedFooter(ParquetEncryptionKeyInfo),
 }
 
 /// Describes general parquet encryption configuration -- new files are encrypted with the

--- a/parquet/src/file/encryption.rs
+++ b/parquet/src/file/encryption.rs
@@ -44,8 +44,8 @@ pub struct ParquetEncryptionKeyInfo {
 pub enum ParquetEncryptionMode {
     /// Means the file is unencrypted
     Unencrypted,
-    /// Means the file is footer-encrypted -- well, fully-encrypted.  The same key is used for all
-    /// the columns too, in this implementation.
+    /// Means the file is encrypted with encrypted footer mode.  The same
+    /// key is used for all the columns too, in this implementation.
     FooterEncrypted(ParquetEncryptionKeyInfo),
 }
 

--- a/parquet/src/file/footer.rs
+++ b/parquet/src/file/footer.rs
@@ -63,7 +63,7 @@ fn select_key(
         for mode in read_keys {
             match mode {
                 ParquetEncryptionMode::Unencrypted => {}
-                ParquetEncryptionMode::FooterEncrypted(key_info) => {
+                ParquetEncryptionMode::EncryptedFooter(key_info) => {
                     if key_info.key.compute_key_hash() == key_id_arr {
                         return Ok(key_info.key);
                     }
@@ -128,7 +128,7 @@ pub fn parse_metadata<R: ChunkReader>(
                 config
                     .read_keys()
                     .iter()
-                    .any(|m| matches!(m, ParquetEncryptionMode::FooterEncrypted(_)))
+                    .any(|m| matches!(m, ParquetEncryptionMode::EncryptedFooter(_)))
             });
             if !has_keys {
                 return Err(general_err!(

--- a/parquet/src/file/footer.rs
+++ b/parquet/src/file/footer.rs
@@ -41,6 +41,7 @@ use crate::schema::types::{self, SchemaDescriptor};
 use crate::file::{
     encryption::{
         decrypt_module, parquet_magic, ParquetEncryptionConfig, ParquetEncryptionKey,
+        ParquetEncryptionMode,
         ParquetEncryptionKeyInfo, RandomFileIdentifier, AAD_FILE_UNIQUE_SIZE,
         PARQUET_KEY_HASH_LENGTH,
     },
@@ -52,17 +53,22 @@ fn select_key(
     key_metadata: &Option<Vec<u8>>,
 ) -> Result<ParquetEncryptionKey> {
     if let Some(key_id) = key_metadata {
-        if key_id.len() != PARQUET_KEY_HASH_LENGTH {
+         if key_id.len() != PARQUET_KEY_HASH_LENGTH {
             return Err(general_err!(
                 "Unsupported Parquet file.  key_metadata field length is not supported"
             ));
-        }
-        let mut key_id_arr = [0u8; PARQUET_KEY_HASH_LENGTH];
-        key_id_arr.copy_from_slice(&key_id);
-        let read_keys: &[ParquetEncryptionKeyInfo] = encryption_config.read_keys();
-        for key_info in read_keys {
-            if key_info.key.compute_key_hash() == key_id_arr {
-                return Ok(key_info.key);
+         }
+         let mut key_id_arr = [0u8; PARQUET_KEY_HASH_LENGTH];
+         key_id_arr.copy_from_slice(&key_id);
+         let read_keys: &[ParquetEncryptionMode] = encryption_config.read_keys();
+         for mode in read_keys {
+            match mode {
+                ParquetEncryptionMode::Unencrypted => { },
+                ParquetEncryptionMode::FooterEncrypted(key_info) => {
+                    if key_info.key.compute_key_hash() == key_id_arr {
+                        return Ok(key_info.key)
+                    }
+                }
             }
         }
         return Err(general_err!(
@@ -103,20 +109,28 @@ pub fn parse_metadata<R: ChunkReader>(
     default_end_reader.read_exact(&mut default_len_end_buf)?;
 
     // check this is indeed a parquet file
+    let encrypted_footer: bool;
     {
+        // and check that its encryption setting conceivably matches our encryption_config (but without yet checking keys)
         let trailing_magic: &[u8] = &default_len_end_buf[default_end_len - 4..];
-        if trailing_magic != parquet_magic(encryption_config.is_some()) {
-            if trailing_magic == PARQUET_MAGIC {
-                return Err(general_err!("Invalid Parquet file in encrypted mode.  File (or at least the Parquet footer) is not encrypted"));
-            } else if trailing_magic == PARQUET_MAGIC_ENCRYPTED_FOOTER_CUBE {
-                return Err(general_err!(
-                    "Invalid Parquet file in unencrypted mode.  File is encrypted"
-                ));
-            } else if trailing_magic == PARQUET_MAGIC_UNSUPPORTED_PARE {
-                return Err(general_err!("Unsupported Parquet file.  File is encrypted with the standard PARE encryption format"));
-            } else {
-                return Err(general_err!("Invalid Parquet file. Corrupt footer"));
+        if trailing_magic == PARQUET_MAGIC {
+            if let Some(config) = encryption_config {
+                if !config.read_keys().iter().any(|m| matches!(m, ParquetEncryptionMode::Unencrypted)) {
+                    return Err(general_err!("Invalid Parquet file in encrypted mode.  File (or at least the Parquet footer) is not encrypted"));
+                }
             }
+            encrypted_footer = false;
+        } else if trailing_magic == PARQUET_MAGIC_ENCRYPTED_FOOTER_CUBE {
+            let has_keys = encryption_config.as_ref().map_or(false,
+                |config| config.read_keys().iter().any(|m| matches!(m, ParquetEncryptionMode::FooterEncrypted(_))));
+            if !has_keys {
+                return Err(general_err!("Invalid Parquet file in unencrypted mode.  File is encrypted"));
+            }
+            encrypted_footer = true;
+        } else if trailing_magic == PARQUET_MAGIC_UNSUPPORTED_PARE {
+            return Err(general_err!("Unsupported Parquet file.  File is encrypted with the standard PARE encryption format"));
+        } else {
+            return Err(general_err!("Invalid Parquet file. Corrupt footer"));
         }
     }
 
@@ -159,7 +173,8 @@ pub fn parse_metadata<R: ChunkReader>(
     let returned_encryption_key: Option<ParquetEncryptionKey>;
 
     let random_file_identifier: Option<RandomFileIdentifier>;
-    if let Some(encryption_config) = encryption_config {
+    if encrypted_footer {
+        let encryption_config: &ParquetEncryptionConfig = encryption_config.as_ref().unwrap();
         let file_crypto_metadata = {
             let mut prot = TCompactInputProtocol::new(&mut metadata_read);
             TFileCryptoMetaData::read_from_in_protocol(&mut prot).map_err(|e| {

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -743,7 +743,7 @@ mod tests {
     use crate::compression::{create_codec, Codec};
     use crate::file::encryption::{
         generate_random_file_identifier, ParquetEncryptionConfig,
-        ParquetEncryptionKeyInfo, ParquetEncryptionMode
+        ParquetEncryptionKeyInfo, ParquetEncryptionMode,
     };
     use crate::file::reader::Length;
     use crate::file::{
@@ -1367,10 +1367,14 @@ mod tests {
 
         file_writer.close().unwrap();
 
-        let encryption_config = encryption_info
-            .map(|(key_info, _)| ParquetEncryptionConfig::new(vec![ParquetEncryptionMode::FooterEncrypted(key_info)]).unwrap());
+        let encryption_config = encryption_info.map(|(key_info, _)| {
+            ParquetEncryptionConfig::new(vec![ParquetEncryptionMode::FooterEncrypted(
+                key_info,
+            )])
+            .unwrap()
+        });
         let reader = assert_send(
-            SerializedFileReader::new_maybe_encrypted(file, &encryption_config).unwrap()
+            SerializedFileReader::new_maybe_encrypted(file, &encryption_config).unwrap(),
         );
         assert_eq!(reader.num_row_groups(), data.len());
         assert_eq!(
@@ -1479,9 +1483,15 @@ mod tests {
         let buffer = cursor.into_inner().unwrap();
 
         let reading_cursor = crate::file::serialized_reader::SliceableCursor::new(buffer);
-        let encryption_config = encryption_info
-            .map(|(key_info, _)| ParquetEncryptionConfig::new(vec![ParquetEncryptionMode::FooterEncrypted(key_info)]).unwrap());
-        let reader = SerializedFileReader::new_maybe_encrypted(reading_cursor, &encryption_config).unwrap();
+        let encryption_config = encryption_info.map(|(key_info, _)| {
+            ParquetEncryptionConfig::new(vec![ParquetEncryptionMode::FooterEncrypted(
+                key_info,
+            )])
+            .unwrap()
+        });
+        let reader =
+            SerializedFileReader::new_maybe_encrypted(reading_cursor, &encryption_config)
+                .unwrap();
 
         assert_eq!(reader.num_row_groups(), data.len());
         assert_eq!(

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -743,7 +743,7 @@ mod tests {
     use crate::compression::{create_codec, Codec};
     use crate::file::encryption::{
         generate_random_file_identifier, ParquetEncryptionConfig,
-        ParquetEncryptionKeyInfo,
+        ParquetEncryptionKeyInfo, ParquetEncryptionMode
     };
     use crate::file::reader::Length;
     use crate::file::{
@@ -1368,9 +1368,9 @@ mod tests {
         file_writer.close().unwrap();
 
         let encryption_config = encryption_info
-            .map(|(key_info, _)| ParquetEncryptionConfig::new(vec![key_info]).unwrap());
+            .map(|(key_info, _)| ParquetEncryptionConfig::new(vec![ParquetEncryptionMode::FooterEncrypted(key_info)]).unwrap());
         let reader = assert_send(
-            SerializedFileReader::new_maybe_encrypted(file, &encryption_config).unwrap(),
+            SerializedFileReader::new_maybe_encrypted(file, &encryption_config).unwrap()
         );
         assert_eq!(reader.num_row_groups(), data.len());
         assert_eq!(
@@ -1480,10 +1480,8 @@ mod tests {
 
         let reading_cursor = crate::file::serialized_reader::SliceableCursor::new(buffer);
         let encryption_config = encryption_info
-            .map(|(key_info, _)| ParquetEncryptionConfig::new(vec![key_info]).unwrap());
-        let reader =
-            SerializedFileReader::new_maybe_encrypted(reading_cursor, &encryption_config)
-                .unwrap();
+            .map(|(key_info, _)| ParquetEncryptionConfig::new(vec![ParquetEncryptionMode::FooterEncrypted(key_info)]).unwrap());
+        let reader = SerializedFileReader::new_maybe_encrypted(reading_cursor, &encryption_config).unwrap();
 
         assert_eq!(reader.num_row_groups(), data.len());
         assert_eq!(

--- a/parquet/src/file/writer.rs
+++ b/parquet/src/file/writer.rs
@@ -1368,7 +1368,7 @@ mod tests {
         file_writer.close().unwrap();
 
         let encryption_config = encryption_info.map(|(key_info, _)| {
-            ParquetEncryptionConfig::new(vec![ParquetEncryptionMode::FooterEncrypted(
+            ParquetEncryptionConfig::new(vec![ParquetEncryptionMode::EncryptedFooter(
                 key_info,
             )])
             .unwrap()
@@ -1484,7 +1484,7 @@ mod tests {
 
         let reading_cursor = crate::file::serialized_reader::SliceableCursor::new(buffer);
         let encryption_config = encryption_info.map(|(key_info, _)| {
-            ParquetEncryptionConfig::new(vec![ParquetEncryptionMode::FooterEncrypted(
+            ParquetEncryptionConfig::new(vec![ParquetEncryptionMode::EncryptedFooter(
                 key_info,
             )])
             .unwrap()


### PR DESCRIPTION
So now read key sets can be `[Unencrypted, key1, key2]` when starting out.